### PR TITLE
Expose diagnostic metadata properties at top level

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .testTarget(name: "MeterTests",
                     dependencies: ["Meter"],
                     resources: [
-                        .copy("Resources"),
+                        .process("Resources"),
                     ]),
         .testTarget(name: "BinaryImageTests",
                     dependencies: ["BinaryImage"]),

--- a/Sources/Meter/DiagnosticPayload.swift
+++ b/Sources/Meter/DiagnosticPayload.swift
@@ -272,7 +272,7 @@ public class HangMetaData: Codable {
     public let osVersion: String
     public let platformArchitecture: String
     public let regionFormat: String
-    private let hangDuration: String
+    public let hangDuration: String
 
     enum CodingKeys: String, CodingKey {
         case applicationBuildVersion = "appBuildVersion"
@@ -284,14 +284,14 @@ public class HangMetaData: Codable {
         case hangDuration
     }
 
-    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String) {
+    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String, hangDuration: String) {
         self.deviceType = deviceType
         self.applicationBuildVersion = applicationBuildVersion
         self.applicationVersion = applicationVersion
         self.osVersion = osVersion
         self.platformArchitecture = platformArchitecture
         self.regionFormat = regionFormat
-        self.hangDuration = ""
+        self.hangDuration = hangDuration
     }
 
     public init(diagnostic: HangDiagnostic) {
@@ -301,7 +301,7 @@ public class HangMetaData: Codable {
         self.osVersion = diagnostic.metaData.osVersion
         self.platformArchitecture = diagnostic.metaData.platformArchitecture
         self.regionFormat = diagnostic.metaData.regionFormat
-        self.hangDuration = ""
+        self.hangDuration = diagnostic.metaData.hangDuration
     }
 
     public func jsonRepresentation() -> Data {
@@ -324,6 +324,10 @@ public class HangDiagnostic: Codable {
         self.version = "1.0.0"
         self.internalMetaData = metaData
         self.callStackTree = callStackTree
+    }
+
+    public var hangDuration: String {
+        return internalMetaData.hangDuration
     }
 
     public func jsonRepresentation() -> Data {
@@ -350,8 +354,8 @@ public class CPUExceptionMetaData: Codable {
     public let osVersion: String
     public let platformArchitecture: String
     public let regionFormat: String
-    private let totalCPUTime: String
-    private let totalSampledTime: String
+    public let totalCPUTime: String
+    public let totalSampledTime: String
 
     enum CodingKeys: String, CodingKey {
         case applicationBuildVersion = "appBuildVersion"
@@ -364,15 +368,15 @@ public class CPUExceptionMetaData: Codable {
         case totalSampledTime
     }
 
-    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String) {
+    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String, totalCPUTime: String, totalSampledTime: String) {
         self.deviceType = deviceType
         self.applicationBuildVersion = applicationBuildVersion
         self.applicationVersion = applicationVersion
         self.osVersion = osVersion
         self.platformArchitecture = platformArchitecture
         self.regionFormat = regionFormat
-        self.totalCPUTime = ""
-        self.totalSampledTime = ""
+        self.totalCPUTime = totalCPUTime
+        self.totalSampledTime = totalSampledTime
     }
 
     public init(diagnostic: CPUExceptionDiagnostic) {
@@ -382,8 +386,8 @@ public class CPUExceptionMetaData: Codable {
         self.osVersion = diagnostic.metaData.osVersion
         self.platformArchitecture = diagnostic.metaData.platformArchitecture
         self.regionFormat = diagnostic.metaData.regionFormat
-        self.totalCPUTime = ""
-        self.totalSampledTime = ""
+        self.totalCPUTime = diagnostic.metaData.totalCPUTime
+        self.totalSampledTime = diagnostic.metaData.totalSampledTime
     }
 
     public func jsonRepresentation() -> Data {
@@ -406,6 +410,14 @@ public class CPUExceptionDiagnostic: Codable {
         self.version = "1.0.0"
         self.internalMetaData = metaData
         self.callStackTree = callStackTree
+    }
+
+    public var totalCPUTime: String {
+        return internalMetaData.totalCPUTime
+    }
+
+    public var totalSampledTime: String {
+        return internalMetaData.totalSampledTime
     }
 
     public func jsonRepresentation() -> Data {
@@ -432,7 +444,7 @@ public class DiskWriteExceptionMetaData: Codable {
     public let osVersion: String
     public let platformArchitecture: String
     public let regionFormat: String
-    private let writesCaused: String
+    public let writesCaused: String
 
     enum CodingKeys: String, CodingKey {
         case applicationBuildVersion = "appBuildVersion"
@@ -444,14 +456,14 @@ public class DiskWriteExceptionMetaData: Codable {
         case writesCaused
     }
 
-    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String) {
+    public init(deviceType: String, applicationBuildVersion: String, applicationVersion: String, osVersion: String, platformArchitecture: String, regionFormat: String, writesCaused: String) {
         self.deviceType = deviceType
         self.applicationBuildVersion = applicationBuildVersion
         self.applicationVersion = applicationVersion
         self.osVersion = osVersion
         self.platformArchitecture = platformArchitecture
         self.regionFormat = regionFormat
-        self.writesCaused = ""
+        self.writesCaused = writesCaused
     }
 
     public init(diagnostic: DiskWriteExceptionDiagnostic) {
@@ -461,7 +473,7 @@ public class DiskWriteExceptionMetaData: Codable {
         self.osVersion = diagnostic.metaData.osVersion
         self.platformArchitecture = diagnostic.metaData.platformArchitecture
         self.regionFormat = diagnostic.metaData.regionFormat
-        self.writesCaused = ""
+        self.writesCaused = diagnostic.metaData.writesCaused
     }
 
     public func jsonRepresentation() -> Data {
@@ -484,6 +496,10 @@ public class DiskWriteExceptionDiagnostic: Codable {
         self.version = "1.0.0"
         self.internalMetaData = metaData
         self.callStackTree = callStackTree
+    }
+
+    public var writesCaused: String {
+        return internalMetaData.writesCaused
     }
 
     public func jsonRepresentation() -> Data {


### PR DESCRIPTION
The interesting bits of data for each diagnostic type are on the metadata types. However those properties were also private so not accessible to users of Meter. Let's expose them as public but also add convenience accessors at the diagnostic type level.

I also changed the bundling of the test resources because `.copy` was introducing a level of indirection/nesting in the final bundle that caused the tests to fail in Xcode 14.2. With the `.copy` and the extra level of nesting the paths in the tests would need to change, and given there were no resources with the same name being merged into the bundle that seemed unnecessary.

| Before | After |
| --- | --- |
| ![CleanShot 2023-02-02 at 15 48 25@2x](https://user-images.githubusercontent.com/1282845/216452187-35834537-04b2-4f04-bfd9-e576b2336c65.png) | ![CleanShot 2023-02-02 at 15 49 45@2x](https://user-images.githubusercontent.com/1282845/216452177-145e0499-b1b6-40b8-a104-b3953e9cf425.png) |


Addresses #7 
